### PR TITLE
Update model_extension.rb

### DIFF
--- a/lib/papercrop/model_extension.rb
+++ b/lib/papercrop/model_extension.rb
@@ -67,7 +67,7 @@ module Papercrop
       # @return [Paperclip::Geometry]
       def image_geometry(attachment_name, style = :original)
         @geometry ||= {}
-        path = (self.send(attachment_name).options[:storage] == :s3) ? self.send(attachment_name).url(style) : self.send(attachment_name).path(style)
+        path = (self.send(attachment_name).options[:storage] == :filesystem) ? self.send(attachment_name).path(style) : self.send(attachment_name).url(style)
         @geometry[style] ||= Paperclip::Geometry.from_file(path)
       end
 


### PR DESCRIPTION
The earlier check for choosing the URL for a path was looking only for the s3 storage option. It does not work if the paperclip's storage model is fog. This proposed change works with either filesystem or s3 or fog and should support any storage model that supports URL.
